### PR TITLE
ENH: Addition of an install rule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(COMMAND CMAKE_POLICY)
   cmake_policy(SET CMP0003 NEW)
 endif()
 
-
+project(ITKUtils)
 
 # Find ITK.
 find_package(ITK REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,8 @@ include(${ITK_USE_FILE})
 add_executable(InvertDeformationField InvertDeformationField.cxx )
 
 target_link_libraries(InvertDeformationField ${ITK_LIBRARIES})
+
+set(INSTALL_RUNTIME_DESTINATION bin CACHE STRING "Install destination")
+
+install(TARGETS InvertDeformationField DESTINATION ${INSTALL_RUNTIME_DESTINATION})
+


### PR DESCRIPTION
The installation rule installs InvertDeformationField in ${CMAKE_INSTALL_PREFIX}/${INSTALL_RUNTIME_DESTINATION}.
INSTALL_RUNTIME_DESTINATION is a CACHE variable that can be set in the command line when configuring the ITKUtils project.
